### PR TITLE
Update getting_started.rst

### DIFF
--- a/getting_started.rst
+++ b/getting_started.rst
@@ -16,7 +16,7 @@ Ubuntu 18.04+
    sudo add-apt-repository 'deb http://mcpelauncher.mrarm.io/apt/ubuntu/ bionic main'
    sudo apt-get install msa-daemon msa-ui-qt mcpelauncher-client mcpelauncher-ui-qt
 
-You will need to install 32 bit graphics drivers - for integrated graphics and most AMD GPUs :code:`libegl1-mesa:i386 libegl1-mesa-drivers:i386` will work.
+You will need to install 32 bit graphics drivers - for integrated graphics and most AMD GPUs :code:`libegl1-mesa:i386 libegl1-mesa-dev:i386` will work.
 
 If you want to compile from sources on Ubuntu 18.04+ `go here <https://github.com/minecraft-linux/linux-packaging-scripts/wiki#ubuntu-1804>`__.
 


### PR DESCRIPTION
Update the getting started page to install the right package. `libegl1-mesa-dev:i386` is needed to prevent libEGL crashes. `libegl1-mesa-drivers:i386` is not available on 18.04.