### PR TITLE
Add section on "this browser or app may not be secure"

### DIFF
--- a/troubleshooting.rst
+++ b/troubleshooting.rst
@@ -66,6 +66,10 @@ There are some solutions, you can:
 
 - Find a suitable Linux Distro (anything Ubuntu-based will be the easiest)
 
+macOS X Mojave - :code:`This browser or app may not be secure. Try using a different browser`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Try using [@ChristopherHX's fork](https://github.com/ChristopherHX/mcpelauncher-manifest/releases) which uses a different workaround for 1.13 support than the standard launcher.  For support, contact @ChristopherHX on the [Discord chat room](https://discord.gg/TaUNBXr).
+
 File picking doesn't work or crashes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 You need to install the :code:`zenity` utility:


### PR DESCRIPTION
Add section directing users to the @ChristopherHX fork for a certain error on Mac OS X, as mentioned in the pinned messages of the #support channel on Discord.