### PR TITLE
Add Flatpak to getting_started.rst

### DIFF
--- a/getting_started.rst
+++ b/getting_started.rst
@@ -82,6 +82,18 @@ A prebuilt **AppImage binary** is `available here <https://mcpelauncher.mrarm.io
 
 This is generally the preferred way if your OS is not one of the ones listed above.
 
+Flatpak
+--------
+
+You can also install mcpelauncher via [Flatpak](https://flathub.org/apps/details/io.mrarm.mcpelauncher)
+To install it, first [setup Flatpak](https://flatpak.org/setup/) then run
+.. code:: bash
+   sudo flatpak install flathub io.mrarm.mcpelauncher
+   
+To run it, run
+.. code:: bash
+   flatpak run io.mrarm.mcpelauncher
+
 Source build
 ------------
 If there are no packages available for your distribution, check out the |Source build guide|_.


### PR DESCRIPTION
Added the option to run the mcpelauncher via Flatpak, as I've found that it's the only way I can consistently run it without errors (and on the latest version of Minecraft) on Ubuntu 20.04.