### PR TITLE
Replace make -j12 to the number of logical cores.

### DIFF
--- a/source_build/launcher.rst
+++ b/source_build/launcher.rst
@@ -16,7 +16,7 @@ Build instructions
    git clone --recursive https://github.com/minecraft-linux/mcpelauncher-manifest.git mcpelauncher && cd mcpelauncher
    mkdir -p build && cd build
    cmake ..
-   make -j12
+   make -j$(getconf _NPROCESSORS_ONLN)
 
 **Important note:** Please note that you may need to replace `cmake ..` with `cmake -DMSA_DAEMON_PATH=/absolute/path/to/daemon/build/dir/msa-daemon ..` if you didn't install the MSA daemon (e.g. if you ran the previous command in /home/paul/, you'd have to use /home/paul/msa/build/msa-daemon as the path). Note the .. is preceded by a space and is not part of the path to the daemon.
 

--- a/source_build/msa.rst
+++ b/source_build/msa.rst
@@ -15,7 +15,7 @@ Build instructions
    git clone --recursive https://github.com/minecraft-linux/msa-manifest.git msa && cd msa
    mkdir -p build && cd build
    cmake -DENABLE_MSA_QT_UI=ON ..
-   make -j12
+   make -j$(getconf _NPROCESSORS_ONLN)
 
 **macOS:** replace the :code:`cmake` line with :code:`cmake -DCMAKE_PREFIX_PATH=$(brew --prefix qt) -DENABLE_MSA_QT_UI=ON ..`
 


### PR DESCRIPTION
https://stackoverflow.com/questions/2499070/gnu-make-should-the-number-of-jobs-equal-the-number-of-cpu-cores-in-a-system
It is reccomended that one sets the number CPU cores to the number of logical CPU cores to the jobs for make.

https://stackoverflow.com/a/23569003 
$() is command replacement in bash, and getconf is a macOS/Linux compatible way to get the logical processors.