### PR TITLE
Update macOS build instructions

### DIFF
--- a/source_build/launcher.rst
+++ b/source_build/launcher.rst
@@ -7,7 +7,7 @@ Prerequirements
 ---------------
 - **Ubuntu** (Up to date as of 2021-07-27) - you'll need to install the required packages: :code:`sudo apt-get install --no-install-recommends g++ clang cmake make git ca-certificates libssl-dev libpng-dev libx11-dev libxi-dev libcurl4-openssl-dev libudev-dev libevdev-dev libegl1-mesa-dev libssl-dev libasound2 qtbase5-dev qtwebengine5-dev qtdeclarative5-dev libqt5svg5-dev qml-module-qtquick2 qml-module-qtquick-layouts qml-module-qtquick-controls qml-module-qtquick-controls2 qml-module-qtquick-window2 qml-module-qtquick-dialogs qml-module-qt-labs-settings qml-module-qt-labs-folderlistmodel qml-module-qtwebengine`
 - **Fedora** (Needs verification) - you'll need to install the required packages: :code:`sudo dnf install gcc-c++ clang cmake make git ca-certificates libstdc++ glibc-devel libpng-devel zlib-devel libX11-devel libXi-devel libcurl-devel systemd-devel libevdev-devel mesa-libEGL-devel alsa-lib pulseaudio-libs mesa-dri-drivers systemd-devel libXtst-devel openssl-devel qt5-qtbase-devel qt5-qtwebengine-devel qt5-qtdeclarative-devel qt5-qtsvg-devel qt5-qtquickcontrols qt5-qtquickcontrols2`
-- **macOS** (Outdated as of 2021-07-27) - :code:`brew install cmake libpng openssl@1.1`
+- **macOS** - :code:`brew install cmake libpng openssl@1.1`
 
 Build instructions
 ------------------
@@ -17,6 +17,8 @@ Build instructions
    mkdir -p build && cd build
    CC=clang CXX=clang++ cmake .. -Wno-dev -DCMAKE_BUILD_TYPE=Release -DJNI_USE_JNIVM=ON 
    make -j$(getconf _NPROCESSORS_ONLN)
+   
+**macOS:** Add the options :code:`-DOPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1)` and :code:`-DCMAKE_PREFIX_PATH=$(brew --prefix qt@5)`.
 
 **Important note:** Please note that you may need to replace `cmake ..` with `cmake -DMSA_DAEMON_PATH=/absolute/path/to/daemon/build/dir/msa-daemon ..` if you didn't install the MSA daemon (e.g. if you ran the previous command in /home/paul/, you'd have to use /home/paul/msa/build/msa-daemon as the path). Note the .. is preceded by a space and is not part of the path to the daemon.
 

--- a/source_build/launcher.rst
+++ b/source_build/launcher.rst
@@ -7,7 +7,7 @@ Prerequirements
 ---------------
 - **Ubuntu** (Up to date as of 2021-07-27) - you'll need to install the required packages: :code:`sudo apt-get install --no-install-recommends g++ clang cmake make git ca-certificates libssl-dev libpng-dev libx11-dev libxi-dev libcurl4-openssl-dev libudev-dev libevdev-dev libegl1-mesa-dev libssl-dev libasound2 qtbase5-dev qtwebengine5-dev qtdeclarative5-dev libqt5svg5-dev qml-module-qtquick2 qml-module-qtquick-layouts qml-module-qtquick-controls qml-module-qtquick-controls2 qml-module-qtquick-window2 qml-module-qtquick-dialogs qml-module-qt-labs-settings qml-module-qt-labs-folderlistmodel qml-module-qtwebengine`
 - **Fedora** (Needs verification) - you'll need to install the required packages: :code:`sudo dnf install gcc-c++ clang cmake make git ca-certificates libstdc++ glibc-devel libpng-devel zlib-devel libX11-devel libXi-devel libcurl-devel systemd-devel libevdev-devel mesa-libEGL-devel alsa-lib pulseaudio-libs mesa-dri-drivers systemd-devel libXtst-devel openssl-devel qt5-qtbase-devel qt5-qtwebengine-devel qt5-qtdeclarative-devel qt5-qtsvg-devel qt5-qtquickcontrols qt5-qtquickcontrols2`
-- **macOS** - :code:`brew install cmake libpng openssl@1.1`
+- **macOS** - :code:`brew install cmake libpng openssl@1.1 qt@5`
 
 Build instructions
 ------------------
@@ -18,7 +18,7 @@ Build instructions
    CC=clang CXX=clang++ cmake .. -Wno-dev -DCMAKE_BUILD_TYPE=Release -DJNI_USE_JNIVM=ON 
    make -j$(getconf _NPROCESSORS_ONLN)
    
-**macOS:** Add the options :code:`-DOPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1)` and :code:`-DCMAKE_PREFIX_PATH=$(brew --prefix qt@5)`.
+**macOS:** Add the following options to the cmake command: :code:`-DOPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1) -DCMAKE_PREFIX_PATH=$(brew --prefix qt@5)`.
 
 **Important note:** Please note that you may need to replace `cmake ..` with `cmake -DMSA_DAEMON_PATH=/absolute/path/to/daemon/build/dir/msa-daemon ..` if you didn't install the MSA daemon (e.g. if you ran the previous command in /home/paul/, you'd have to use /home/paul/msa/build/msa-daemon as the path). Note the .. is preceded by a space and is not part of the path to the daemon.
 

--- a/source_build/msa.rst
+++ b/source_build/msa.rst
@@ -6,7 +6,7 @@ Prerequirements
 - **Ubuntu 18.04+** - :code:`sudo apt-get install libssl-dev libcurl4-openssl-dev qtbase5-dev qtwebengine5-dev`
 - **Ubuntu 16.04** - You must add a Qt 5.9+ repository first (:code:`add-apt-repository ppa:beineri/opt-qt596-xenial && apt-get update`) from which you should install :code:`apt-get install qt59base qt59webengine`; also install :code:`apt-get install libssl-dev libcurl4-openssl-dev`
 - **Fedora** - :code:`sudo dnf install openssl-devel libcurl-devel qt5-qtbase-devel qt5-qtwebengine-devel`
-- **macOS** - :code:`brew install cmake qt`
+- **macOS** - :code:`brew install cmake qt@5`
 
 Build instructions
 ------------------
@@ -17,7 +17,7 @@ Build instructions
    cmake -DENABLE_MSA_QT_UI=ON ..
    make -j$(getconf _NPROCESSORS_ONLN)
 
-**macOS:** replace the :code:`cmake` line with :code:`cmake -DCMAKE_PREFIX_PATH=$(brew --prefix qt) -DENABLE_MSA_QT_UI=ON ..`
+**macOS:** replace the :code:`cmake` line with :code:`cmake -DCMAKE_PREFIX_PATH=$(brew --prefix qt@5) -DENABLE_MSA_QT_UI=ON ..`
 
 Installation
 ------------


### PR DESCRIPTION
I tried building with the instructions and cmake failed. The latest version of Qt on brew is now 6, so I tried installing version 5 and the build worked. I assume this is the correct thing to do.