### PR TITLE
Add note about Wayland causing software rendering issues

### DIFF
--- a/src/troubleshooting/index.md
+++ b/src/troubleshooting/index.md
@@ -104,7 +104,7 @@ your hardware.
 You may need to reinstall the proprietary drivers if you had installed
 them manually before.
 
-Performance can also degrade by [running under Xwayland](#i-am-running-into-glitches-with-xwayland).
+Performance can also degrade by [running under Xwayland](#i-am-running-into-glitches-with-xwayland). If you are on a Wayland session and experiencing software rendering or graphical issues, try switching to an X11 session or running the game [natively under Wayland](#run-natively-under-wayland).
 
 ### Black screen with Mesa 23.1+
 
@@ -223,6 +223,11 @@ window manager, you will run into issues that will affect your experience.
 These issues are beyond the scope of this project and should be reported
 upstream. There are two solutions: Fallback to an X11 session, or run the game
 natively under Wayland.
+
+> **Note:** If you are experiencing software rendering (llvmpipe) or other
+> graphics performance issues under Wayland, switching to an X11 session
+> is often the simplest fix. You can do this by selecting "X11" or "Xorg"
+> from your display manager's session menu at the login screen.
 
 #### Run natively under Wayland
 

--- a/src/troubleshooting/index.md
+++ b/src/troubleshooting/index.md
@@ -104,7 +104,7 @@ your hardware.
 You may need to reinstall the proprietary drivers if you had installed
 them manually before.
 
-Performance can also degrade by [running under Xwayland](#i-am-running-into-glitches-with-xwayland). If you are on a Wayland session and experiencing software rendering or graphical issues, try switching to an X11 session or running the game [natively under Wayland](#run-natively-under-wayland).
+Performance can also degrade by [running under Xwayland](#i-am-running-into-glitches-with-xwayland). If you are on a Wayland session and experiencing software rendering or graphical issues, try switching to an X11 session or building with native Wayland support (see [below](#run-natively-under-wayland)). Note that the default game window system (EGLUT) only supports X11, so the game runs under XWayland unless built with SDL3 or GLFW.
 
 ### Black screen with Mesa 23.1+
 
@@ -231,9 +231,10 @@ natively under Wayland.
 
 #### Run natively under Wayland
 
-By default, the binary does not come with native Wayland support. 
-You will need to [build the game launcher from source](../source_build/index.md) 
-with SDL3 to enable native wayland support.
+By default, the binary uses EGLUT for the game window, which only supports X11
+(running under XWayland on Wayland sessions). To get native Wayland support, you
+will need to [build the game launcher from source](../source_build/index.md)
+with either `-DGAMEWINDOW_SYSTEM=SDL3` or `-DGAMEWINDOW_SYSTEM=GLFW`.
 
 Once you have the game launcher built with Wayland support, you will need to
 force the client to run under Wayland, as it will still default to running 


### PR DESCRIPTION
## Summary

- Expands the "Graphics performance issues" troubleshooting section to mention that Wayland sessions can cause software rendering, with links to both the X11 fallback and native Wayland options
- Adds a practical note in the "Xwayland glitches" section explaining how to switch to an X11 session from the display manager login screen

Closes #82

## Context

As reported in #82, switching from Wayland to X11 can resolve software rendering issues. The existing troubleshooting page already had a section about Xwayland glitches but didn't clearly connect Wayland to the software rendering problem or explain the simplest fix (switching sessions at the login screen).

## Test plan

- [ ] Verify the internal anchor links (`#run-natively-under-wayland`, `#i-am-running-into-glitches-with-xwayland`) resolve correctly in the rendered mdbook output
- [ ] Confirm the blockquote note renders properly in mdbook